### PR TITLE
Note detection

### DIFF
--- a/note-detection.js
+++ b/note-detection.js
@@ -253,12 +253,6 @@ function note_types(measures, one_beat) {
                 }
             } else { //There is a remainder, was not held for a whole number of beats
                 if (quotient_temp > 0) { //Only do this is there's full beats not accounted for
-                    // Special case: dotted single beat note
-                    if (quotient_temp == 1 && temp == 16) {
-                        note_obj.note_type.push("48/32");
-                        measure_updated.push(note_obj);
-                        continue;
-                    }
                     //Perform same steps as above
                     if (Math.log2(quotient_temp) % 1 === 0) {
                         note_obj.note_type.push(quotient_temp);

--- a/note-detection.js
+++ b/note-detection.js
@@ -10,8 +10,12 @@ const fraction_of_beat = {
 }
 
 module.exports = {
-    get_notes : function(buffer, time_signature, tempo) {// see below for optional constructor parameters.
+    get_notes : function(buffer, time_signature_top, time_signature_bottom, tempo) {// see below for optional constructor parameters.
 
+        console.log(time_signature_top);
+        console.log(time_signature_bottom);
+        
+        
         time_signature = "4/4";
         const detectPitch = new Pitchfinder.AMDF();
 
@@ -38,8 +42,10 @@ module.exports = {
         var combined = combine_notes(notes);
         console.log('Notes combined based on consecutive samples of the same note', JSON.parse(JSON.stringify(combined)));
         
-        var beats_per_measure = time_signature.split("/")[0];
-        var one_beat = time_signature.split("/")[1];
+        //var beats_per_measure = time_signature.split("/")[0];
+        //var one_beat = time_signature.split("/")[1];
+        var beats_per_measure = time_signature_top;
+        var one_beat = time_signature_bottom;
     
         var measures = measures_split(combined, beats_per_measure);
         console.log('Notes divided into subarrays by measures', measures);

--- a/note-detection.js
+++ b/note-detection.js
@@ -15,7 +15,6 @@ module.exports = {
         console.log(time_signature_top);
         console.log(time_signature_bottom);
         
-        time_signature = "4/4";
         const detectPitch = new Pitchfinder.AMDF();
 
         /*const decoded = WavDecoder.decode.sync(buffer); // get audio data from file using `wav-decoder`
@@ -43,9 +42,6 @@ module.exports = {
     
         var measures = measures_split(combined, time_signature_top);
         console.log('Notes divided into subarrays by measures', measures);
-
-        /*measures = note_types(measures, one_beat);
-        console.log('Measures assigned note types', measures);*/
 
         var new_measures = note_types(measures, time_signature_bottom);
         console.log('Notes with assigned note types', new_measures);

--- a/note-detection.js
+++ b/note-detection.js
@@ -29,7 +29,7 @@ module.exports = {
         var notes = frequencies.map(freq => freq < 1109 && freq != null ? 
                                 {
                                     "freq" : freq, 
-                                    "note_name" : "" + teoria.note.fromFrequency(freq).note.name() 
+                                    "note_name" : "" + teoria.note.fromFrequency(freq).note.name().toUpperCase()
                                                 + teoria.note.fromFrequency(freq).note.octave()
                                                 + teoria.note.fromFrequency(freq).note.accidental(),
                                 } : {"freq" : null, "note_name" : "rest"});
@@ -38,18 +38,6 @@ module.exports = {
         var combined = combine_notes(notes);
         console.log('Notes combined based on consecutive samples of the same note', combined);
         
-
-        // Change accidental signs (#, b) to fit lilypond format
-        /*for (var i = 0; i < combined.length; ++i) {   
-            if (combined[i].accidental) {
-                if (combined[i].accidental == "#") {
-                    combined[i].accidental = "is";
-                } else if (combined[i].accidental == "b") {
-                    combined[i].accidental = "es";
-                }
-            }
-        }*/
-
         var beats_per_measure = time_signature.split("/")[0];
         var one_beat = time_signature.split("/")[1];
     

--- a/note-detection.js
+++ b/note-detection.js
@@ -212,52 +212,6 @@ function note_types(measures, one_beat) {
 
     var res = [];
 
-    /*for (var i = 0; i < measures.length; ++i) {
-        measure = JSON.parse(JSON.stringify(measures[i]));
-        measure_updated = [];
-        for (var j = 0; j < measure.length; ++j) {
-            // Convert a note's sample length to a note type (half, quarter, 8th, 16th, etc)
-            note_type = samples_per_beat / measure[j].note_length * one_beat;
-            note_obj = JSON.parse(JSON.stringify(measure[j]));
-            if (note_type % 1 == 0) {
-                //Note type is a multiple of whole number (half, quarter, 8th, 16th, etc)
-                note_obj.note_type = "" + note_type;
-            } else {
-                // Conversion does not cleanly divide into a whole number (dotted note / tied note)
-                // Get number of beats a note takes up
-                temp = note_obj.note_length / samples_per_beat;
-                if (temp == 0.75) { //dotted half beat = 0.5 + 0.25 = 0.75
-                    note_obj.note_type = 2 * one_beat + ".";
-                } else if (temp == 1.25) {  //single beat + quarter beat (slurred over two notes)
-                    note_obj.note_type = one_beat + "~ " + (one_beat * 4);
-                } else if (temp == 1.5) { //dotted single beat = 1.5
-                    note_obj.note_type = one_beat + ".";
-                } else if (temp == 1.75) { //single beat + 3/4 beat (slurred over two notes)
-                    note_obj.note_type = one_beat + "~ " + (2 * one_beat);
-                } else if (temp > 2 && temp < 3) { // between 2 and 3 beats
-                    multiplier = fraction_of_beat[note_obj.note_length % samples_per_beat];
-                    note_obj.note_type = (one_beat / 2) + "~ " + (multiplier[0] * one_beat + multiplier[1]);
-                } else if (temp == 3) { //dotted 2 beat = 3 beats (dotted half note)
-                    note_obj.note_type = one_beat / 2 + ".";
-                } else if (temp > 3 && temp < 4) { //Between a 3 beats and 4 beats
-                    multiplier = fraction_of_beat[note_obj.note_length % samples_per_beat];
-                    note_obj.note_type = (one_beat / 2 + ".") + "~ " + (multiplier[0] * one_beat + multiplier[1]);
-                } else if (temp > 4 && temp < 5) { //between 4 and 5 beats
-                    multiplier = fraction_of_beat[note_obj.note_length % samples_per_beat];
-                    note_obj.note_type = (one_beat / 4) + "~ " + (multiplier[0] * one_beat + multiplier[1]);
-                } else if (temp > 5 && temp < 6) { //between 5 and 6 beats
-                    multiplier = fraction_of_beat[note_obj.note_length % samples_per_beat];
-                    note_obj.note_type = (one_beat / 4 + "~ " + one_beat + "~ " + multiplier[0] * one_beat + multiplier[1]);
-                }else { //dotted 4 beat = 6 beats
-                    note_obj.note_type = one_beat / 4 + ".";
-                }
-            }
-            measure_updated.push(note_obj);
-        }
-        
-        res.push(measure_updated);
-    }*/
-
     for (var i = 0; i < measures.length; ++i) {
         measure = JSON.parse(JSON.stringify(measures[i]));
         measure_updated = [];
@@ -299,6 +253,12 @@ function note_types(measures, one_beat) {
                 }
             } else { //There is a remainder, was not held for a whole number of beats
                 if (quotient_temp > 0) { //Only do this is there's full beats not accounted for
+                    // Special case: dotted single beat note
+                    if (quotient_temp == 1 && temp == 16) {
+                        note_obj.note_type.push("48/32");
+                        measure_updated.push(note_obj);
+                        continue;
+                    }
                     //Perform same steps as above
                     if (Math.log2(quotient_temp) % 1 === 0) {
                         note_obj.note_type.push(quotient_temp);

--- a/note-detection.js
+++ b/note-detection.js
@@ -15,7 +15,6 @@ module.exports = {
         console.log(time_signature_top);
         console.log(time_signature_bottom);
         
-        
         time_signature = "4/4";
         const detectPitch = new Pitchfinder.AMDF();
 
@@ -41,19 +40,14 @@ module.exports = {
         
         var combined = combine_notes(notes);
         console.log('Notes combined based on consecutive samples of the same note', JSON.parse(JSON.stringify(combined)));
-        
-        //var beats_per_measure = time_signature.split("/")[0];
-        //var one_beat = time_signature.split("/")[1];
-        var beats_per_measure = time_signature_top;
-        var one_beat = time_signature_bottom;
     
-        var measures = measures_split(combined, beats_per_measure);
+        var measures = measures_split(combined, time_signature_top);
         console.log('Notes divided into subarrays by measures', measures);
 
         /*measures = note_types(measures, one_beat);
         console.log('Measures assigned note types', measures);*/
 
-        var new_measures = note_types(measures, one_beat);
+        var new_measures = note_types(measures, time_signature_bottom);
         console.log('Notes with assigned note types', new_measures);
         
 

--- a/note-detection.js
+++ b/note-detection.js
@@ -40,7 +40,7 @@ module.exports = {
         
 
         // Change accidental signs (#, b) to fit lilypond format
-        for (var i = 0; i < combined.length; ++i) {   
+        /*for (var i = 0; i < combined.length; ++i) {   
             if (combined[i].accidental) {
                 if (combined[i].accidental == "#") {
                     combined[i].accidental = "is";
@@ -48,16 +48,20 @@ module.exports = {
                     combined[i].accidental = "es";
                 }
             }
-        }
+        }*/
 
         var beats_per_measure = time_signature.split("/")[0];
-        one_beat = time_signature.split("/")[1];
+        var one_beat = time_signature.split("/")[1];
     
         var measures = measures_split(combined, beats_per_measure);
         console.log('Notes divided into subarrays by measures', measures);
 
         /*measures = note_types(measures, one_beat);
         console.log('Measures assigned note types', measures);*/
+
+        var new_measures = note_types(measures, one_beat);
+        console.log('Notes with assigned note types', new_measures);
+        
 
         return measures;
         
@@ -220,7 +224,7 @@ function note_types(measures, one_beat) {
 
     var res = [];
 
-    for (var i = 0; i < measures.length; ++i) {
+    /*for (var i = 0; i < measures.length; ++i) {
         measure = JSON.parse(JSON.stringify(measures[i]));
         measure_updated = [];
         for (var j = 0; j < measure.length; ++j) {
@@ -263,6 +267,59 @@ function note_types(measures, one_beat) {
             measure_updated.push(note_obj);
         }
         
+        res.push(measure_updated);
+    }*/
+
+    for (var i = 0; i < measures.length; ++i) {
+        measure = JSON.parse(JSON.stringify(measures[i]));
+        measure_updated = [];
+        for (var j = 0; j < measure.length; ++j) {
+            note_obj = JSON.parse(JSON.stringify(measure[j]));
+            temp = note_obj.note_length % samples_per_beat;
+            quotient = parseInt(note_obj.note_length / samples_per_beat);
+
+            note_obj.note_type = [];
+            quotient_temp = quotient;
+            while (quotient_temp - one_beat > 0) {
+                note_obj.note_type.push(one_beat);
+                quotient_temp -= one_beat;
+            }
+
+            if (temp == 0) {
+                if (quotient_temp <= one_beat) {
+                    if (Math.log2(quotient_temp) % 1 === 0) {
+                        note_obj.note_type.push(quotient_temp);
+                        measure_updated.push(note_obj);
+                    } else {
+                        if (quotient_temp == 3) {
+                            note_obj.note_type.push(quotient_temp);
+                            measure_updated.push(note_obj);
+                        } else {
+                            low_pow = Math.pow(2,Math.floor(Math.log2(quotient_temp)));
+                            rest = quotient_temp - low_pow;
+                            note_obj.note_type.push(low_pow, rest);
+                            measure_updated.push(note_obj);
+                        }
+                    }
+                }
+            } else {
+                if (quotient_temp != 0) {
+                    if (Math.log2(quotient_temp) % 1 === 0) {
+                        note_obj.note_type.push(quotient_temp);
+                    } else {
+                        if (quotient_temp == 3) {
+                            note_obj.note_type.push(quotient_temp);
+                        } else {
+                            low_pow = Math.pow(2,Math.floor(Math.log2(quotient_temp)));
+                            rest = quotient_temp - low_pow;
+                            note_obj.note_type.push(low_pow, rest);
+                        }
+                    }
+                }
+                note_obj.note_type.push(temp + "/" + samples_per_beat);
+                measure_updated.push(note_obj);
+            }
+        }
         res.push(measure_updated);
     }
 

--- a/note-detection.js
+++ b/note-detection.js
@@ -36,7 +36,7 @@ module.exports = {
         console.log(notes);
         
         var combined = combine_notes(notes);
-        console.log('Notes combined based on consecutive samples of the same note', combined);
+        console.log('Notes combined based on consecutive samples of the same note', JSON.parse(JSON.stringify(combined)));
         
         var beats_per_measure = time_signature.split("/")[0];
         var one_beat = time_signature.split("/")[1];
@@ -77,7 +77,7 @@ function combine_notes(notes) {
 
     // Iterating through the sampled audio
     for (var i = 0; i < notes.length; ++i) {
-        note = notes[i];
+        note = JSON.parse(JSON.stringify(notes[i]));
 
         /* If the index is 0, or the counter for consecutive notes has been reset, create
         a new note object from the current index to begin comparing subsequent elements */
@@ -147,7 +147,7 @@ function measures_split(combined_notes, beats_per_measure) {
 
     // Combine notes based on measure
     for (var i = 0; i < combined_notes.length; ++i) {
-        note_obj = combined_notes[i];
+        note_obj = JSON.parse(JSON.stringify(combined_notes[i]));
 
         // Note is below the lowest threshold to be considered a 16th note (fastest note user can sing)
         if (note_obj.note_length < 5)

--- a/renderer.js
+++ b/renderer.js
@@ -16,8 +16,6 @@ var recording = false;
 var detectTempoButton = document.getElementById("detect-tempo-button");
 var tempoCountdown = document.getElementById("tempo-countdown");
 var tempoInput = document.querySelector("input[name='tempo']");
-var time_signature_top_num_input = document.querySelector('[name="time-signature-top-num"]');
-var time_signature_bottom_num_input = document.querySelector('[name="time-signature-bottom-num"]');
 var detectingTempoContent =  document.getElementById("detecting-tempo-div");
 var taps;
 var startTime, endTime;
@@ -140,7 +138,7 @@ function createAudioBuffer(blob) {
                     // Speech to text
                     syncRecognize(blob, audioBuffer.sampleRate);
                     // Note-detection
-                    measures = note_detection.get_notes(audioBuffer, time_signature_top_num_input.value, time_signature_bottom_num_input.value, tempoInput.value);
+                    measures = note_detection.get_notes(audioBuffer, time_signature_top_num_input, time_signature_bottom_num_input, tempo_input);
                 }, function (e) {
                     "Error decoding data"
                 }));

--- a/renderer.js
+++ b/renderer.js
@@ -16,6 +16,8 @@ var recording = false;
 var detectTempoButton = document.getElementById("detect-tempo-button");
 var tempoCountdown = document.getElementById("tempo-countdown");
 var tempoInput = document.querySelector("input[name='tempo']");
+var time_signature_top_num_input = document.querySelector('[name="time-signature-top-num"]');
+var time_signature_bottom_num_input = document.querySelector('[name="time-signature-bottom-num"]');
 var detectingTempoContent =  document.getElementById("detecting-tempo-div");
 var taps;
 var startTime, endTime;
@@ -138,7 +140,7 @@ function createAudioBuffer(blob) {
                     // Speech to text
                     syncRecognize(blob, audioBuffer.sampleRate);
                     // Note-detection
-                    measures = note_detection.get_notes(audioBuffer, "4/4", tempoInput.value);
+                    measures = note_detection.get_notes(audioBuffer, time_signature_top_num_input.value, time_signature_bottom_num_input.value, tempoInput.value);
                 }, function (e) {
                     "Error decoding data"
                 }));

--- a/test/test_note_detection.js
+++ b/test/test_note_detection.js
@@ -227,11 +227,29 @@ describe('note_detection.js note_types() function unit tests', function() {
         var expected = [
             [
                 { note_name_full : "C4", note : "C", octave : "4", note_length : 24, note_type : ["24/32"] },
-                { note_name_full : "C4", note : "C", octave : "4", note_length : 48, note_type : [1, "16/32"] },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 48, note_type : ["48/32"] },
                 { note_name_full : "C4", note : "C", octave : "4", note_length : 96, note_type : [3] },
                 { note_name_full : "C4", note : "C", octave : "4", note_length : 192, note_type : [4, 2] },
             ]
         ];
+
+        var res = note_detect.note_types(arr, one_beat);
+
+        expect(res).to.eql(expected);
+    });
+
+    it('For notes longer than a whole note, should tie notes with whole notes as the largest', function() {
+        var arr = [
+            [
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 560 }
+            ]
+        ];
+
+        var expected = [
+            [
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 560, note_type : [4, 4, 4, 4, "48/32"] }
+            ]
+        ]
 
         var res = note_detect.note_types(arr, one_beat);
 

--- a/test/test_note_detection.js
+++ b/test/test_note_detection.js
@@ -8,23 +8,27 @@ var note_detect = require("../note-detection.js");
 describe('note_detection.js combine_notes() function unit tests', function() {
     it('From an array of sampled notes, combine consecutive notes of the same note name', function() {
         var arr = [
-            { note_name : "c4", freq : 0 },
-            { note_name : "c4", freq : 0 },
-            { note_name : "d4", freq : 0 },
-            { note_name : "e4", freq : 0 },
-            { note_name : "e4", freq : 0 },
-            { note_name : "e4", freq : 0 },
-            { note_name : "e4b", freq : 0 },
+            { note_name : "C4", freq : 0 },
+            { note_name : "C4", freq : 0 },
+            { note_name : "C4", freq : 0 },
+            { note_name : "C4", freq : 0 },
+            { note_name : "C4", freq : 0 },
+            { note_name : "D4", freq : 0 },
+            { note_name : "E4", freq : 0 },
+            { note_name : "E4", freq : 0 },
+            { note_name : "E4", freq : 0 },
+            { note_name : "E4", freq : 0 },
+            { note_name : "E4b", freq : 0 },
             { note_name : "rest", freq : 0 },
             { note_name : "rest", freq : 0 },
             { note_name : "rest", freq : 0 },
         ];
 
         var expected = [
-            { note_name_full : "c4", note : "c", octave : "4", accidental : undefined, freq : 0, note_length : 2 },
-            { note_name_full : "d4", note : "d", octave : "4", accidental : undefined, freq : 0, note_length : 1 },
-            { note_name_full : "e4", note : "e", octave : "4", accidental : undefined, freq : 0, note_length : 3 },
-            { note_name_full : "e4b", note : "e", octave : "4", accidental : "b", freq : 0, note_length : 1 },
+            { note_name_full : "C4", note : "C", octave : "4", accidental : undefined, freq : 0, note_length : 5 },
+            { note_name_full : "D4", note : "D", octave : "4", accidental : undefined, freq : 0, note_length : 1 },
+            { note_name_full : "E4", note : "E", octave : "4", accidental : undefined, freq : 0, note_length : 4 },
+            { note_name_full : "E4b", note : "E", octave : "4", accidental : "b", freq : 0, note_length : 1 },
             { note_name_full : "rest", note : "rest", freq : 0, note_length : 3 },
         ];
 
@@ -35,17 +39,17 @@ describe('note_detection.js combine_notes() function unit tests', function() {
 
     it('If the array is all one note, return should be array of size 1 with note_length == input.length', function() {
         var arr = [
-            { note_name : "c4", freq : 0 },
-            { note_name : "c4", freq : 0 },
-            { note_name : "c4", freq : 0 },
-            { note_name : "c4", freq : 0 },
-            { note_name : "c4", freq : 0 },
-            { note_name : "c4", freq : 0 },
-            { note_name : "c4", freq : 0 }
+            { note_name : "C4", freq : 0 },
+            { note_name : "C4", freq : 0 },
+            { note_name : "C4", freq : 0 },
+            { note_name : "C4", freq : 0 },
+            { note_name : "C4", freq : 0 },
+            { note_name : "C4", freq : 0 },
+            { note_name : "C4", freq : 0 }
         ];
 
         var expected = [
-            { note_name_full : "c4", note : "c", octave : "4", accidental : undefined, freq : 0, note_length : 7 },
+            { note_name_full : "C4", note : "C", octave : "4", accidental : undefined, freq : 0, note_length : 7 },
         ];
 
         var res = note_detect.combine_notes(arr);
@@ -58,9 +62,9 @@ describe('note_detection.js measures_split() function unit tests', function() {
 
     it('Function should round note lengths to the nearest multiple of 8', function() {
         var arr = [
-            { note_name_full : "c4", note : "c", octave : "4", note_length : 7 },
-            { note_name_full : "f4", note : "f", octave : "4", note_length : 18 },
-            { note_name_full : "a5", note : "a", octave : "5", note_length : 84 },
+            { note_name_full : "C4", note : "C", octave : "4", note_length : 7 },
+            { note_name_full : "F4", note : "F", octave : "4", note_length : 18 },
+            { note_name_full : "A5", note : "A", octave : "5", note_length : 84 },
         ];
 
         var res = note_detect.measures(arr, beats_per_measure);
@@ -72,37 +76,37 @@ describe('note_detection.js measures_split() function unit tests', function() {
 
     it('Function should filter out note lengths below the lowest note threshold of 8 after rounding', function() {
         var arr = [
-            { note_name_full : "c4", note : "c", octave : "4", note_length : 4 },
+            { note_name_full : "C4", note : "C", octave : "4", note_length : 4 },
         ];
 
         var res = note_detect.measures(arr, beats_per_measure);
 
         //Should remove the c4 note since it's less than 8 when rounded
-        expect(res[0][0].note_name_full).to.not.eql("c4");
+        expect(res[0][0].note_name_full).to.not.eql("C4");
     });
 
     it('Function should divide the array of notes into subarrays based on beats per measure', function() {
         var arr = [
             // Measure 1
-            { note_name_full : "c4", note : "c", octave : "4", note_length : 23 },
-            { note_name_full : "d4", note : "d", octave : "4", note_length : 18 },
-            { note_name_full : "e4", note : "e", octave : "4", note_length : 84 },
+            { note_name_full : "C4", note : "C", octave : "4", note_length : 23 },
+            { note_name_full : "D4", note : "D", octave : "4", note_length : 18 },
+            { note_name_full : "E4", note : "E", octave : "4", note_length : 84 },
             //Measure 2
-            { note_name_full : "f4", note : "f", octave : "5", note_length : 30 },
-            { note_name_full : "g4", note : "g", octave : "5", note_length : 61 },
-            { note_name_full : "a5", note : "a", octave : "5", note_length : 32 },
+            { note_name_full : "F4", note : "F", octave : "5", note_length : 30 },
+            { note_name_full : "G4", note : "G", octave : "5", note_length : 61 },
+            { note_name_full : "A5", note : "A", octave : "5", note_length : 32 },
         ];
 
         var expected = [
             [
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 24 },
-                { note_name_full : "d4", note : "d", octave : "4", note_length : 16 },
-                { note_name_full : "e4", note : "e", octave : "4", note_length : 88 },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 24 },
+                { note_name_full : "D4", note : "D", octave : "4", note_length : 16 },
+                { note_name_full : "E4", note : "E", octave : "4", note_length : 88 },
             ],
             [
-                { note_name_full : "f4", note : "f", octave : "5", note_length : 32 },
-                { note_name_full : "g4", note : "g", octave : "5", note_length : 64 },
-                { note_name_full : "a5", note : "a", octave : "5", note_length : 32 },
+                { note_name_full : "F4", note : "F", octave : "5", note_length : 32 },
+                { note_name_full : "G4", note : "G", octave : "5", note_length : 64 },
+                { note_name_full : "A5", note : "A", octave : "5", note_length : 32 },
             ]
         ];
 
@@ -114,12 +118,12 @@ describe('note_detection.js measures_split() function unit tests', function() {
 
     it('Append a rest to the end of the last measure if the measure is not filled', function() {
         var arr = [
-            { note_name_full : "c4", note : "c", octave : "4", note_length : 48 }
+            { note_name_full : "C4", note : "C", octave : "4", note_length : 48 }
         ];
 
         var expected = [
             [
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 48 },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 48 },
                 { note_name_full : "rest", note : "rest", note_length : 80 }
             ]
         ];
@@ -133,17 +137,17 @@ describe('note_detection.js measures_split() function unit tests', function() {
     it('If a note goes begins in a measure but does not have space for the full note ' + 
     'split the note and put the rest in another measure', function() {
         var arr = [
-            { note_name_full : "c4", note : "c", octave : "4", note_length : 48 },
-            { note_name_full : "g4", note : "g", octave : "4", note_length : 128 }
+            { note_name_full : "C4", note : "C", octave : "4", note_length : 48 },
+            { note_name_full : "G4", note : "G", octave : "4", note_length : 128 }
         ];
 
         var expected = [
             [
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 48 },
-                { note_name_full : "g4", note : "g", octave : "4", note_length : 80, tied : true }
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 48 },
+                { note_name_full : "G4", note : "G", octave : "4", note_length : 80, tied : true }
             ],
             [
-                { note_name_full : "g4", note : "g", octave : "4", note_length : 48 },
+                { note_name_full : "G4", note : "G", octave : "4", note_length : 48 },
                 { note_name_full : "rest", note : "rest", note_length : 80 }
             ]
         ];
@@ -155,18 +159,18 @@ describe('note_detection.js measures_split() function unit tests', function() {
 
     it('Notes longer than a measure should be split into the number of needed measures', function() {
         var arr = [
-            { note_name_full : "c4", note : "c", octave : "4", note_length : 320 }
+            { note_name_full : "C4", note : "C", octave : "4", note_length : 320 }
         ];
 
         var expected = [
             [
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 128, tied : true },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 128, tied : true },
             ],
             [
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 128, tied : true },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 128, tied : true },
             ],
             [
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 64 },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 64 },
                 { note_name_full : "rest", note : "rest", note_length : 64 },
             ]
         ];
@@ -186,21 +190,21 @@ describe('note_detection.js note_types() function unit tests', function() {
         var arr = [
             [
                 //Subarray size unimportant, checking proper note_length --> note_type conversion
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 8 },
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 16 },
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 32 },
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 64 },
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 128 },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 8 },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 16 },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 32 },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 64 },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 128 },
             ]
         ];
 
         var expected = [
             [
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 8, note_type : "16" },
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 16, note_type : "8" },
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 32, note_type : "4" },
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 64, note_type : "2" },
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 128, note_type : "1" },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 8, note_type : ["8/32"] },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 16, note_type : ["16/32"] },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 32, note_type : [1] },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 64, note_type : [2] },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 128, note_type : [4] },
             ]
         ];
 
@@ -213,19 +217,19 @@ describe('note_detection.js note_types() function unit tests', function() {
         var arr = [
             [
                 //Subarray size unimportant, checking proper note_length --> note_type conversion
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 24 },
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 48 },
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 96 },
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 192 },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 24 },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 48 },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 96 },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 192 },
             ]
         ];
 
         var expected = [
             [
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 24, note_type : "8." },
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 48, note_type : "4." },
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 96, note_type : "2." },
-                { note_name_full : "c4", note : "c", octave : "4", note_length : 192, note_type : "1." },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 24, note_type : ["24/32"] },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 48, note_type : [1, "16/32"] },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 96, note_type : [3] },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 192, note_type : [4, 2] },
             ]
         ];
 

--- a/test/test_note_detection.js
+++ b/test/test_note_detection.js
@@ -227,7 +227,7 @@ describe('note_detection.js note_types() function unit tests', function() {
         var expected = [
             [
                 { note_name_full : "C4", note : "C", octave : "4", note_length : 24, note_type : ["24/32"] },
-                { note_name_full : "C4", note : "C", octave : "4", note_length : 48, note_type : ["48/32"] },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 48, note_type : [1, "16/32"] },
                 { note_name_full : "C4", note : "C", octave : "4", note_length : 96, note_type : [3] },
                 { note_name_full : "C4", note : "C", octave : "4", note_length : 192, note_type : [4, 2] },
             ]
@@ -247,12 +247,34 @@ describe('note_detection.js note_types() function unit tests', function() {
 
         var expected = [
             [
-                { note_name_full : "C4", note : "C", octave : "4", note_length : 560, note_type : [4, 4, 4, 4, "48/32"] }
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 560, note_type : [4, 4, 4, 4, 1, "16/32"] }
             ]
         ]
 
         var res = note_detect.note_types(arr, one_beat);
 
+        expect(res).to.eql(expected);
+    });
+
+    it('Should tie notes appropriately', function() {
+        var arr = [
+            [
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 112 },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 56 },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 80 }
+            ]
+        ];
+
+        var expected = [
+            [
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 112, note_type : [3, "16/32"] },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 56, note_type : [1, "24/32"] },
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 80, note_type : [2, "16/32"] }
+            ]
+        ];
+
+        var res = note_detect.note_types(arr, one_beat);
+        
         expect(res).to.eql(expected);
     });
 });

--- a/test/test_note_detection.js
+++ b/test/test_note_detection.js
@@ -277,4 +277,44 @@ describe('note_detection.js note_types() function unit tests', function() {
         
         expect(res).to.eql(expected);
     });
+
+    it ('Should divide into powers of 2 for differing time signature (x/16)', function() {
+        one_beat = 16;
+
+        var arr = [
+            [
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 416 }
+            ]
+        ];
+
+        var expected = [
+            [
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 416, note_type : [8, 4, 1] }
+            ]
+        ];
+
+        var res = note_detect.note_types(arr, one_beat);
+        
+        expect(res).to.eql(expected);
+    })
+
+    it ('Should divide into powers of 2 for differing time signature (x/8)', function() {
+        one_beat = 8;
+
+        var arr = [
+            [
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 224 }
+            ]
+        ];
+
+        var expected = [
+            [
+                { note_name_full : "C4", note : "C", octave : "4", note_length : 224, note_type : [4, 3] }
+            ]
+        ];
+
+        var res = note_detect.note_types(arr, one_beat);
+        
+        expect(res).to.eql(expected);
+    });
 });


### PR DESCRIPTION
Notes will now get assigned a `note_type` value for their lengths proportional to the `L` value inputted into abcjs.  For example, with `L: 1/4` a `note_type` of 1 and 1/2 would be a quarter note and eighth note, respectively.

Note: Will not handle dotted single beat notes (dotted quarter note in x/4 time). Instead, displays it as a single beat note tied to a half beat note (quarter note tied to eighth note).