### PR TITLE
remove extra speech-to-text.js from head

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
     <script src="./selectButtons.js" type="text/javascript"></script>
     <script src="./speech-to-text.js" type="text/javascript"></script>
     <script src="./words-to-syllables.js" type="text/javascript"></script>
-    <script src="./speech-to-text.js" type="text/javascript"></script>
     <script src="./detect-key.js" type="text/javascript"></script>
     <script src="./renderSheetMusic.js" type="text/javascript"></script>
     <title>Noteable</title>


### PR DESCRIPTION
Super simple bug fix. We accidentally included the speech-to-text.js twice causing a syntax error